### PR TITLE
Add nltk to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name="nlup",
       author="Kyle Gorman",
       author_email="kylebgorman@gmail.com",
       url="http://github.com/cslu-nlp/nlup/",
-      install_requires=["jsonpickle >= 0.9.0"],
+      install_requires=["jsonpickle >= 0.9.0", "nltk >= 3.1"],
       packages=["nlup"],
       keywords=["nlp", "natural language processing", "text", "text processing", "ai", "artificial intelligence", "neural net", "perceptron", "data", "science", "statistics", "data science", "math", "machine learning", "computer science", "information theory"],
       classifiers=[


### PR DESCRIPTION
Right now, installing nlup in a vanilla Python environment and attempting to import it will fail:
```
$ python -c 'import nlup'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/constantinelignos/miniconda3/envs/nlup/lib/python3.6/site-packages/nlup/__init__.py", line 27, in <module>
    from .readers import *
  File "/Users/constantinelignos/miniconda3/envs/nlup/lib/python3.6/site-packages/nlup/readers.py", line 25, in <module>
    from nltk import str2tuple, tuple2str
ModuleNotFoundError: No module named 'nltk'
```

The cause is that `install_requires` does not list nltk, even though it's required to even import nlup. This MR addresses that, using the version of nltk listed in the requirements. Tested on Python 3.6 in a clean Anaconda environment.