### PR TITLE
Remove dependency on nltk

### DIFF
--- a/nlup/readers.py
+++ b/nlup/readers.py
@@ -20,8 +20,28 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-from nltk import str2tuple
-from nltk import tuple2str
+def str2tuple(tt):
+  """
+  Convert tagged token like 'fly/VB' into a tuple like ('fly', 'VB'). If no '/'
+  is found, return (tt, None). If multiple '/' are found, ignore all but the
+  last;  e.g., 'on/off/NN' results in ('on/off', 'NN')
+  """
+  token_tag = tt.rsplit('/', 1)
+  if len(token_tag) > 1:
+    return token_tag[0], token_tag[1].upper()
+  return token_tag[0], None
+
+
+def tuple2str(tt):
+  """
+  Convert a ('token', 'tag') tuple into single-string 'token/tag' form.
+  If the tag is None, just the token is returned; if the tag contains the
+  separator, '/', an AssertionError is raised.
+  """
+  if tt[1] is None:
+    return tt[0]
+  assert '/' not in tt[1], 'tag must not contain "/"'
+  return '%s/%s' % tt
 
 
 def untagged_corpus(filename):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-nltk==3.1
 jsonpickle==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author_email="kylebgorman@gmail.com",
     url="http://github.com/cslu-nlp/nlup/",
     license="MIT",
-    install_requires=["jsonpickle >= 0.9.0", "nltk >= 3.1"],
+    install_requires=["jsonpickle >= 0.9.0"],
     packages=["nlup"],
     keywords=[
         "nlp",


### PR DESCRIPTION
I like [`DetectorMorse`](https://github.com/cslu-nlp/DetectorMorse), which is the best (Python) rule-based sentence boundary detector I've evaluated :), but I don't like having to pull in `nltk` (especially as a transitive dependency). This PR gets rid of the dependency on `nltk` by reimplementing `nltk(.tag.util)`'s `str2tuple` and `tuple2str` helpers. The only behavior difference, besides `nltk` parameterizing the separator character, is that this implementation of `tuple2str` will _not_ raise a `ValueError: too many values to unpack (expected 2)` when encountering a tag-token tuple that happens to contain more than two values (`nltk` _will_ throw in that case).

See https://github.com/nltk/nltk/blob/3.1/nltk/tag/util.py#L9-L56 for the original implementation.

P.S. Thanks for `DetectorMorse`; it works a treat!